### PR TITLE
CO-6492: Exclude root NVMe device from ephemeral list for C5, M5 instance types.

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -44,6 +44,11 @@ module EphemeralLvm
         # Support for NVMe devices - example I3
         if node['ec2']
           ephemeral_devices += Dir.glob("/dev/nvme*n1")
+
+          # Remove root disk from the list
+          if ::File.read('/proc/mounts').include?('/dev/nvme0n1p1 / ')
+            ephemeral_devices -= ['/dev/nvme0n1']
+          end
         end
 
         # Removes nil elements from the ephemeral_devices array if any.
@@ -58,6 +63,9 @@ module EphemeralLvm
           )
           Chef::Log.info "Ephemeral disks found for cloud '#{cloud}': #{ephemeral_devices.inspect}"
         end
+
+        # Check that devices exist
+        ephemeral_devices.select! { |x| ::File.exist?(x) }
       else
         # Cloud specific ephemeral detection logic if the cloud doesn't support block_device_mapping
         #

--- a/metadata.json
+++ b/metadata.json
@@ -130,7 +130,7 @@
   "recipes": {
     "ephemeral_lvm::default": "Sets up ephemeral devices on a cloud server"
   },
-  "version": "1.60.0",
+  "version": "1.70.0",
   "source_url": "",
   "issues_url": ""
 }


### PR DESCRIPTION
Hi @autrejacoupa , please take a look. Thanks.