### PR TITLE
CO-6492: C5 AWS instances don't have ephemeral at all.

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -42,13 +42,9 @@ module EphemeralLvm
         end
 
         # Support for NVMe devices - example I3
-        if node['ec2']
+        # Skip for C5 and etc where root and regular EBS volumes for db are also nvme
+        if node['ec2'] && !::File.read('/proc/mounts').include?('/dev/nvme0n1p1 / ')
           ephemeral_devices += Dir.glob("/dev/nvme*n1")
-
-          # Remove root disk from the list
-          if ::File.read('/proc/mounts').include?('/dev/nvme0n1p1 / ')
-            ephemeral_devices -= ['/dev/nvme0n1']
-          end
         end
 
         # Removes nil elements from the ephemeral_devices array if any.

--- a/metadata.json
+++ b/metadata.json
@@ -130,7 +130,7 @@
   "recipes": {
     "ephemeral_lvm::default": "Sets up ephemeral devices on a cloud server"
   },
-  "version": "1.70.0",
+  "version": "1.71.0",
   "source_url": "",
   "issues_url": ""
 }


### PR DESCRIPTION
We determine such instances as those that have nvme as root device.

@autrejacoupa , please review. Thanks.