### PR TITLE
added support nvme for c5/m5/r5

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -41,11 +41,14 @@ module EphemeralLvm
           end
         end
 
-        # Support for NVMe devices - example I3
-        # Skip for C5 and etc where root and regular EBS volumes for db are also nvme
-        if node['ec2'] && !::File.read('/proc/mounts').include?('/dev/nvme0n1p1 / ')
-          ephemeral_devices += Dir.glob("/dev/nvme*n1")
-        end
+        # Support for NVMe devices - example i3/c5/m5/r5
+		# c5/m5/r5 root device is nmve divice, so skip all mounted devices 
+
+        if node['ec2']
+			Dir.glob("/dev/nvme*n1").each do |nvme_device|
+            	ephemeral_devices.push nvme_device unless ::File.read('/proc/mounts').include?(nvme_device)
+			end
+		end
 
         # Removes nil elements from the ephemeral_devices array if any.
         ephemeral_devices.compact!

--- a/metadata.json
+++ b/metadata.json
@@ -11,8 +11,8 @@
     "debian": ">= 0.0.0"
   },
   "dependencies": {
-    "lvm": "~> 1.3.6",
-    "filesystem": "~> 0.10.0"
+    "lvm": "~> 4.5.1",
+    "filesystem": "~> 1.0.0"
   },
   "recommendations": {
   },

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,7 +66,7 @@ else
       # If random encryption_key is already set, it's most likely due to reboot.
       if node['ephemeral_lvm']['encryption_key'].to_s.empty?
         # Passing 128 to hex returns string of 128*2=256
-        node.set['ephemeral_lvm']['encryption_key'] = SecureRandom.hex(128)
+        node.default['ephemeral_lvm']['encryption_key'] = SecureRandom.hex(128)
         node.save unless Chef::Config[:solo] #Do not loose it if chef run fails
       end
       encryption_key = node['ephemeral_lvm']['encryption_key']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,7 +66,7 @@ else
       # If random encryption_key is already set, it's most likely due to reboot.
       if node['ephemeral_lvm']['encryption_key'].to_s.empty?
         # Passing 128 to hex returns string of 128*2=256
-        node.default['ephemeral_lvm']['encryption_key'] = SecureRandom.hex(128)
+        node.normal['ephemeral_lvm']['encryption_key'] = SecureRandom.hex(128)
         node.save unless Chef::Config[:solo] #Do not loose it if chef run fails
       end
       encryption_key = node['ephemeral_lvm']['encryption_key']


### PR DESCRIPTION
## JIRA

https://coupadev.atlassian.net/browse/CO-7596
https://coupadev.atlassian.net/browse/CO-7641

- [ ] @Ramesh7 
- [ ] @abril
- [x] @alokdnb 

## Summary of issue
New instance_types m5d/c5d/r5d use nvme storage devices by default. So root device is /dev/nvmeX as well. added support /dev/nvme devices for ephemeral stores.

## Testing approach

- [x] Manual test ( converge ec2 instances manually and from swift job )
- [ ] No test (please specify why)

### Ops Cookbook Review (ops_cookbook)

- [ ] @charchitcoupa
  - This rule is always triggered
