### PR TITLE
disabled luks encription for nvme devices

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,3 +40,6 @@ default['ephemeral_lvm']['encryption'] = false
 
 # Encryption key
 default['ephemeral_lvm']['encryption_key'] = nil
+
+# Does ephemeral device type nvme?
+default['ephemeral_lvm']['nvme_device'] = false

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -45,10 +45,13 @@ module EphemeralLvm
 		# c5/m5/r5 root device is nmve divice, so skip all mounted devices 
 
         if node['ec2']
-			Dir.glob("/dev/nvme*n1").each do |nvme_device|
-            	ephemeral_devices.push nvme_device unless ::File.read('/proc/mounts').include?(nvme_device)
-			end
-		end
+           Dir.glob("/dev/nvme*n1").each do |nvme_device|
+              unless ::File.read('/proc/mounts').include?(nvme_device)
+                ephemeral_devices.push nvme_device
+                node.normal['ephemeral_lvm']['nvme_device'] = true
+              end
+           end
+        end
 
         # Removes nil elements from the ephemeral_devices array if any.
         ephemeral_devices.compact!

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,6 +56,7 @@ else
     logical_volume_device_name = node['ephemeral_lvm']['volume_group_name'].gsub(/-/,'--') + "-" + node['ephemeral_lvm']['logical_volume_name'].gsub(/-/,'--')
 
     # Encrypt if enabled
+
     if node['ephemeral_lvm']['encryption'] == true || node['ephemeral_lvm']['encryption'] == 'true'
 
       require 'securerandom'
@@ -82,6 +83,8 @@ else
         command "echo -n ${ENCRYPTION_KEY} | cryptsetup luksOpen /dev/mapper/#{logical_volume_device_name} encrypted-#{logical_volume_device_name} --key-file=-"
         not_if { ::File.exists?("/dev/mapper/encrypted-#{logical_volume_device_name}") }
       end
+	else
+	  Chef::Log.info "Ecnrypting skipped, node['ephemeral_lvm']['encryption'] == #{node['ephemeral_lvm']['encryption']}"
     end
 
     # Format, add fstab entry, and mount


### PR DESCRIPTION
[Risk Level label][1]
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CO-7706)
* [JIRA propagation subtask](https://coupadev.atlassian.net/browse/CO-7706)

## Code reviewers

- [  ] @alokdnb 
- [  ] @abriel 
- [  ] @Ramesh7 

## Summary of issue

Learned this from meeting AWS team at Seattle. The SSD NVMe instance stores already have encryption built in. With i3 (used with Elasticsearch) and now c5d, m5d, r5d in ES5 we do not need to setup LUKS based encryption on ephemeral storage.

Disabling LUKS would improve the IO (on mysqltmp and Elasticsearch) and also improve the server boot time.

## Summary of change

added bool attribute as a flag when ephemeral device is nvme device, and used them to process or skip crypt procedure.

## Testing approach
- [x] Manual test

Tested manual on r3.xlarge (non nvme) deployment dev166dbs1 and c5d.xlarge ( nvme ) deployment dev166dbs2