### PR TITLE
CO-9477 Disable LUKS encryption for ephemeral_lvm

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,3 +40,6 @@ default['ephemeral_lvm']['encryption'] = false
 
 # Encryption key
 default['ephemeral_lvm']['encryption_key'] = nil
+
+# Does ephemeral device type nvme?
+default['ephemeral_lvm']['nvme_device'] = false

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -45,10 +45,13 @@ module EphemeralLvm
 		# c5/m5/r5 root device is nmve divice, so skip all mounted devices 
 
         if node['ec2']
-			Dir.glob("/dev/nvme*n1").each do |nvme_device|
-            	ephemeral_devices.push nvme_device unless ::File.read('/proc/mounts').include?(nvme_device)
-			end
-		end
+          Dir.glob('/dev/nvme*n1').each do |nvme_device|
+            unless ::File.read('/proc/mounts').include?(nvme_device)
+              ephemeral_devices.push nvme_device
+              node.normal['ephemeral_lvm']['nvme_device'] = true
+            end
+          end
+        end
 
         # Removes nil elements from the ephemeral_devices array if any.
         ephemeral_devices.compact!


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CO-9477)

## Code reviewers
- [ ] @pallav-jakhotiya  
- [ ] @charchitcoupa 
- [x] @alokdnb 
- [ ] @abriel 
- [ ] @Ramesh7 
- [ ] @kumartushar 

## Summary of issue

nvme ephemeral devices are already encrypted by aws, we dont need to re-encrypt them with LUKS.

## Summary of change

- Disable LUKS encryption only for NVME devices.
- Do not add ephemeral device to `/etc/fstab`, it causes issue on server stop-start. Also On each server boot, cloud-init runs again which runs chef-client, and ephemeral gets mounted again if not present. (in case of stop-start)


## Testing approach

- [x] Manual Test
More on ticket